### PR TITLE
Support passing pond options

### DIFF
--- a/projects/ng-pond/README.md
+++ b/projects/ng-pond/README.md
@@ -223,6 +223,7 @@ For details and additional options, please refer to the `PondOptions` reference 
 
 ```typescript
 import { AppComponent } from './app.component';
+import { FishErrorContext, FishId } from '@actyx/pond';
 import { ActyxPondService } from '@actyx-contrib/ng-pond'
 
 @NgModule({

--- a/projects/ng-pond/README.md
+++ b/projects/ng-pond/README.md
@@ -215,6 +215,38 @@ export const MachineFish = {
   // [..]
 ```
 
+#### 📖 Example: Configure Pond Options
+
+This example shows how to configure the pond's options.
+We add a `fishErrorReporter` and a `defaultSnapshotThreshold`.
+For details and additional options, please refer to the `PondOptions` reference in the developer documentation at https://developer.actyx.com/.
+
+```typescript
+import { AppComponent } from './app.component';
+import { ActyxPondService } from '@actyx-contrib/ng-pond'
+
+@NgModule({
+  declarations: [AppComponent],
+  imports: [BrowserModule],
+  providers: [
+    {
+      provide: 'pondOptions',
+      useValue: {
+        defaultSnapshotThreshold: 42,
+        fishErrorReporter: (
+          err: unknown,
+          fishId: FishId,
+          detail: FishErrorContext
+        ) => console.error(err, fishId, detail),
+      },
+    },
+    ActyxPondService
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule {}
+```
+
 
 ## 📖 Service overview
 

--- a/projects/ng-pond/src/lib/ng-pond.service.spec.ts
+++ b/projects/ng-pond/src/lib/ng-pond.service.spec.ts
@@ -1,3 +1,4 @@
+import { FishErrorContext, FishId } from '@actyx/pond';
 import { TestBed } from '@angular/core/testing';
 
 import { ActyxPondService } from './ng-pond.service';
@@ -12,5 +13,39 @@ describe('ActyxPondService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+});
+
+describe('ActyxPondServiceOptions', () => {
+  let service: ActyxPondService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: 'pondOptions',
+          useValue: {
+            defaultSnapshotThreshold: 42,
+            fishErrorReporter: (
+              err: unknown,
+              fishId: FishId,
+              detail: FishErrorContext
+            ) => console.error(err, fishId, detail),
+          },
+        },
+        ActyxPondService,
+      ],
+    });
+    service = TestBed.inject(ActyxPondService);
+  });
+
+  it('should be passed to pond', async () => {
+    expect(
+      await service
+        .getPond()
+        //@ts-expect-error
+        .then((pond) => pond.opts)
+        .then((opts) => opts.defaultSnapshotThreshold)
+    ).toBe(42);
   });
 });

--- a/projects/ng-pond/src/lib/ng-pond.service.ts
+++ b/projects/ng-pond/src/lib/ng-pond.service.ts
@@ -1,5 +1,5 @@
-import { Injectable } from '@angular/core';
-import { CancelSubscription, Fish, ObserveAllOpts, PendingEmission, Pond, PondInfo, PondState, StateEffect, Tags, Where } from '@actyx/pond'
+import { Inject, Injectable, Optional } from '@angular/core';
+import { CancelSubscription, Fish, ObserveAllOpts, PendingEmission, Pond, PondInfo, PondOptions, PondState, StateEffect, Tags, Where } from '@actyx/pond'
 import { RxPond } from '@actyx-contrib/rx-pond'
 import { from, Observable } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
@@ -11,9 +11,9 @@ import * as Registry from '@actyx-contrib/registry';
 export class ActyxPondService {
   pond: Pond | undefined
   rxPond: RxPond | undefined
-  constructor() {
+  constructor(@Inject('pondOptions') @Optional() pondOptions?: PondOptions) {
     const sv = this
-    Pond.default().then(pond => {
+    Pond.of({}, pondOptions || {}).then(pond => {
       sv.pond = pond
       sv.rxPond = RxPond.from(pond)
     })


### PR DESCRIPTION
Adds the possibility to pass pond options to `ActyxPondService`.
Options are passed by adding a `provider` using the `pondOptions` [injection token](https://angular.io/api/core/InjectionToken).

The parameter is optional and defaults to `{}`, which is what `Pond.default()` does as well.

Closes https://github.com/actyx-contrib/ng-pond/issues/2